### PR TITLE
Fix torchaudio compatibility for PyTorch 2.9+ (avoid TorchCodec issues)

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,3 +1,38 @@
+
+
+# ==== audio backend helper (auto-added) ====
+def _torch_ge_29():
+    try:
+        import torch
+        v = torch.__version__.split("+")[0]
+        major, minor = map(int, v.split(".")[:2])
+        return (major, minor) >= (2, 9)
+    except Exception:
+        return False
+
+def load_audio_segment(audio_path, offset=0, num_frames=None):
+    if not _torch_ge_29():
+        import torchaudio
+        return torchaudio.load(
+            audio_path,
+            frame_offset=offset,
+            num_frames=num_frames
+        )
+
+    import soundfile as sf
+    import torch
+
+    wav, sr = sf.read(audio_path)
+    if wav.ndim == 2:
+        wav = wav.mean(axis=1)
+
+    start = offset or 0
+    end = None if num_frames is None else start + num_frames
+    wav = wav[start:end]
+
+    wav = torch.from_numpy(wav).unsqueeze(0)
+    return wav, sr
+
 import argparse
 import logging
 

--- a/copy_codebase.py
+++ b/copy_codebase.py
@@ -1,4 +1,39 @@
 
+
+# ==== audio backend helper (auto-added) ====
+def _torch_ge_29():
+    try:
+        import torch
+        v = torch.__version__.split("+")[0]
+        major, minor = map(int, v.split(".")[:2])
+        return (major, minor) >= (2, 9)
+    except Exception:
+        return False
+
+def load_audio_segment(audio_path, offset=0, num_frames=None):
+    if not _torch_ge_29():
+        import torchaudio
+        return torchaudio.load(
+            audio_path,
+            frame_offset=offset,
+            num_frames=num_frames
+        )
+
+    import soundfile as sf
+    import torch
+
+    wav, sr = sf.read(audio_path)
+    if wav.ndim == 2:
+        wav = wav.mean(axis=1)
+
+    start = offset or 0
+    end = None if num_frames is None else start + num_frames
+    wav = wav[start:end]
+
+    wav = torch.from_numpy(wav).unsqueeze(0)
+    return wav, sr
+
+
 import os
 import shutil
 import fnmatch

--- a/data/__init__.py
+++ b/data/__init__.py
@@ -1,0 +1,35 @@
+
+
+# ==== audio backend helper (auto-added) ====
+def _torch_ge_29():
+    try:
+        import torch
+        v = torch.__version__.split("+")[0]
+        major, minor = map(int, v.split(".")[:2])
+        return (major, minor) >= (2, 9)
+    except Exception:
+        return False
+
+def load_audio_segment(audio_path, offset=0, num_frames=None):
+    if not _torch_ge_29():
+        import torchaudio
+        return torchaudio.load(
+            audio_path,
+            frame_offset=offset,
+            num_frames=num_frames
+        )
+
+    import soundfile as sf
+    import torch
+
+    wav, sr = sf.read(audio_path)
+    if wav.ndim == 2:
+        wav = wav.mean(axis=1)
+
+    start = offset or 0
+    end = None if num_frames is None else start + num_frames
+    wav = wav[start:end]
+
+    wav = torch.from_numpy(wav).unsqueeze(0)
+    return wav, sr
+

--- a/data/combined_dataset.py
+++ b/data/combined_dataset.py
@@ -1,3 +1,38 @@
+
+
+# ==== audio backend helper (auto-added) ====
+def _torch_ge_29():
+    try:
+        import torch
+        v = torch.__version__.split("+")[0]
+        major, minor = map(int, v.split(".")[:2])
+        return (major, minor) >= (2, 9)
+    except Exception:
+        return False
+
+def load_audio_segment(audio_path, offset=0, num_frames=None):
+    if not _torch_ge_29():
+        import torchaudio
+        return torchaudio.load(
+            audio_path,
+            frame_offset=offset,
+            num_frames=num_frames
+        )
+
+    import soundfile as sf
+    import torch
+
+    wav, sr = sf.read(audio_path)
+    if wav.ndim == 2:
+        wav = wav.mean(axis=1)
+
+    start = offset or 0
+    end = None if num_frames is None else start + num_frames
+    wav = wav[start:end]
+
+    wav = torch.from_numpy(wav).unsqueeze(0)
+    return wav, sr
+
 import copy
 import csv
 import glob

--- a/data/tokenizer.py
+++ b/data/tokenizer.py
@@ -1,3 +1,38 @@
+
+
+# ==== audio backend helper (auto-added) ====
+def _torch_ge_29():
+    try:
+        import torch
+        v = torch.__version__.split("+")[0]
+        major, minor = map(int, v.split(".")[:2])
+        return (major, minor) >= (2, 9)
+    except Exception:
+        return False
+
+def load_audio_segment(audio_path, offset=0, num_frames=None):
+    if not _torch_ge_29():
+        import torchaudio
+        return torchaudio.load(
+            audio_path,
+            frame_offset=offset,
+            num_frames=num_frames
+        )
+
+    import soundfile as sf
+    import torch
+
+    wav, sr = sf.read(audio_path)
+    if wav.ndim == 2:
+        wav = wav.mean(axis=1)
+
+    start = offset or 0
+    end = None if num_frames is None else start + num_frames
+    wav = wav[start:end]
+
+    wav = torch.from_numpy(wav).unsqueeze(0)
+    return wav, sr
+
 from typing import Any, Optional
 
 import torch
@@ -95,6 +130,8 @@ def tokenize_audio(tokenizer: AudioTokenizer, audio_path: str, offset = -1, num_
         wav, sr = torchaudio.load(audio_path)
     target_sr = getattr(tokenizer, "encode_sample_rate", tokenizer.sample_rate)
     if sr != target_sr:
+        # ensure float32 for torchaudio resample
+        wav = wav.to(dtype=torch.float32)
         wav = torchaudio.transforms.Resample(sr, target_sr)(wav)
         sr = target_sr
     if wav.shape[0] == 2:

--- a/duration_estimator.py
+++ b/duration_estimator.py
@@ -1,3 +1,38 @@
+
+
+# ==== audio backend helper (auto-added) ====
+def _torch_ge_29():
+    try:
+        import torch
+        v = torch.__version__.split("+")[0]
+        major, minor = map(int, v.split(".")[:2])
+        return (major, minor) >= (2, 9)
+    except Exception:
+        return False
+
+def load_audio_segment(audio_path, offset=0, num_frames=None):
+    if not _torch_ge_29():
+        import torchaudio
+        return torchaudio.load(
+            audio_path,
+            frame_offset=offset,
+            num_frames=num_frames
+        )
+
+    import soundfile as sf
+    import torch
+
+    wav, sr = sf.read(audio_path)
+    if wav.ndim == 2:
+        wav = wav.mean(axis=1)
+
+    start = offset or 0
+    end = None if num_frames is None else start + num_frames
+    wav = wav[start:end]
+
+    wav = torch.from_numpy(wav).unsqueeze(0)
+    return wav, sr
+
 import os
 import re
 from typing import Optional, Tuple

--- a/examples/data_preprocess/prepare_emilia_en.py
+++ b/examples/data_preprocess/prepare_emilia_en.py
@@ -1,3 +1,38 @@
+
+
+# ==== audio backend helper (auto-added) ====
+def _torch_ge_29():
+    try:
+        import torch
+        v = torch.__version__.split("+")[0]
+        major, minor = map(int, v.split(".")[:2])
+        return (major, minor) >= (2, 9)
+    except Exception:
+        return False
+
+def load_audio_segment(audio_path, offset=0, num_frames=None):
+    if not _torch_ge_29():
+        import torchaudio
+        return torchaudio.load(
+            audio_path,
+            frame_offset=offset,
+            num_frames=num_frames
+        )
+
+    import soundfile as sf
+    import torch
+
+    wav, sr = sf.read(audio_path)
+    if wav.ndim == 2:
+        wav = wav.mean(axis=1)
+
+    start = offset or 0
+    end = None if num_frames is None else start + num_frames
+    wav = wav[start:end]
+
+    wav = torch.from_numpy(wav).unsqueeze(0)
+    return wav, sr
+
 """
 Prepare the English portion of ``amphion/Emilia-Dataset`` for the T5Gemma-TTS
 training using XCodec2 acoustic tokens.

--- a/hf_export/__init__.py
+++ b/hf_export/__init__.py
@@ -1,2 +1,36 @@
-# Local package for exporting the T5Gemma voice model in HF format.
 
+
+# ==== audio backend helper (auto-added) ====
+def _torch_ge_29():
+    try:
+        import torch
+        v = torch.__version__.split("+")[0]
+        major, minor = map(int, v.split(".")[:2])
+        return (major, minor) >= (2, 9)
+    except Exception:
+        return False
+
+def load_audio_segment(audio_path, offset=0, num_frames=None):
+    if not _torch_ge_29():
+        import torchaudio
+        return torchaudio.load(
+            audio_path,
+            frame_offset=offset,
+            num_frames=num_frames
+        )
+
+    import soundfile as sf
+    import torch
+
+    wav, sr = sf.read(audio_path)
+    if wav.ndim == 2:
+        wav = wav.mean(axis=1)
+
+    start = offset or 0
+    end = None if num_frames is None else start + num_frames
+    wav = wav[start:end]
+
+    wav = torch.from_numpy(wav).unsqueeze(0)
+    return wav, sr
+
+# Local package for exporting the T5Gemma voice model in HF format.

--- a/hf_export/configuration_t5gemma_voice.py
+++ b/hf_export/configuration_t5gemma_voice.py
@@ -1,3 +1,38 @@
+
+
+# ==== audio backend helper (auto-added) ====
+def _torch_ge_29():
+    try:
+        import torch
+        v = torch.__version__.split("+")[0]
+        major, minor = map(int, v.split(".")[:2])
+        return (major, minor) >= (2, 9)
+    except Exception:
+        return False
+
+def load_audio_segment(audio_path, offset=0, num_frames=None):
+    if not _torch_ge_29():
+        import torchaudio
+        return torchaudio.load(
+            audio_path,
+            frame_offset=offset,
+            num_frames=num_frames
+        )
+
+    import soundfile as sf
+    import torch
+
+    wav, sr = sf.read(audio_path)
+    if wav.ndim == 2:
+        wav = wav.mean(axis=1)
+
+    start = offset or 0
+    end = None if num_frames is None else start + num_frames
+    wav = wav[start:end]
+
+    wav = torch.from_numpy(wav).unsqueeze(0)
+    return wav, sr
+
 """
 Configuration for inference-only T5GemmaVoice model.
 

--- a/hf_export/modeling_t5gemma_voice.py
+++ b/hf_export/modeling_t5gemma_voice.py
@@ -1,3 +1,38 @@
+
+
+# ==== audio backend helper (auto-added) ====
+def _torch_ge_29():
+    try:
+        import torch
+        v = torch.__version__.split("+")[0]
+        major, minor = map(int, v.split(".")[:2])
+        return (major, minor) >= (2, 9)
+    except Exception:
+        return False
+
+def load_audio_segment(audio_path, offset=0, num_frames=None):
+    if not _torch_ge_29():
+        import torchaudio
+        return torchaudio.load(
+            audio_path,
+            frame_offset=offset,
+            num_frames=num_frames
+        )
+
+    import soundfile as sf
+    import torch
+
+    wav, sr = sf.read(audio_path)
+    if wav.ndim == 2:
+        wav = wav.mean(axis=1)
+
+    start = offset or 0
+    end = None if num_frames is None else start + num_frames
+    wav = wav[start:end]
+
+    wav = torch.from_numpy(wav).unsqueeze(0)
+    return wav, sr
+
 """
 Hugging Face compatible wrapper of the T5Gemma-TTS model.
 

--- a/inference_commandline_hf.py
+++ b/inference_commandline_hf.py
@@ -1,3 +1,38 @@
+
+
+# ==== audio backend helper (auto-added) ====
+def _torch_ge_29():
+    try:
+        import torch
+        v = torch.__version__.split("+")[0]
+        major, minor = map(int, v.split(".")[:2])
+        return (major, minor) >= (2, 9)
+    except Exception:
+        return False
+
+def load_audio_segment(audio_path, offset=0, num_frames=None):
+    if not _torch_ge_29():
+        import torchaudio
+        return torchaudio.load(
+            audio_path,
+            frame_offset=offset,
+            num_frames=num_frames
+        )
+
+    import soundfile as sf
+    import torch
+
+    wav, sr = sf.read(audio_path)
+    if wav.ndim == 2:
+        wav = wav.mean(axis=1)
+
+    start = offset or 0
+    end = None if num_frames is None else start + num_frames
+    wav = wav[start:end]
+
+    wav = torch.from_numpy(wav).unsqueeze(0)
+    return wav, sr
+
 """TTS inference script for HF safetensors.
 
 Thin wrapper to load a T5GemmaVoiceForConditionalGeneration checkpoint saved in
@@ -135,8 +170,15 @@ def run_inference(
         target_generation_length = float(target_duration)
 
     if not no_reference_audio:
-        info = torchaudio.info(reference_speech)
-        prompt_end_frame = int(cut_off_sec * info.sample_rate)
+        if _torch_ge_29():
+            import soundfile as sf
+            info = sf.info(reference_speech)
+            sr = info.samplerate
+        else:
+            import torchaudio
+            info = torchaudio.info(reference_speech)
+            sr = info.sample_rate
+        prompt_end_frame = int(cut_off_sec * sr)
     else:
         prompt_end_frame = 0
 
@@ -179,7 +221,14 @@ def run_inference(
 
     os.makedirs(output_dir, exist_ok=True)
     out_path = os.path.join(output_dir, "generated.wav")
-    torchaudio.save(out_path, gen_audio, codec_audio_sr)
+    if _torch_ge_29():
+        import soundfile as sf
+        sf.write(out_path,
+                 gen_audio.squeeze().detach().cpu().numpy(),
+                 codec_audio_sr)
+    else:
+        import torchaudio
+        torchaudio.save(out_path, gen_audio, codec_audio_sr)
 
     max_abs = torch.max(gen_audio.abs()).item()
     rms = torch.sqrt((gen_audio ** 2).mean()).item()

--- a/inference_gradio.py
+++ b/inference_gradio.py
@@ -1,3 +1,38 @@
+
+
+# ==== audio backend helper (auto-added) ====
+def _torch_ge_29():
+    try:
+        import torch
+        v = torch.__version__.split("+")[0]
+        major, minor = map(int, v.split(".")[:2])
+        return (major, minor) >= (2, 9)
+    except Exception:
+        return False
+
+def load_audio_segment(audio_path, offset=0, num_frames=None):
+    if not _torch_ge_29():
+        import torchaudio
+        return torchaudio.load(
+            audio_path,
+            frame_offset=offset,
+            num_frames=num_frames
+        )
+
+    import soundfile as sf
+    import torch
+
+    wav, sr = sf.read(audio_path)
+    if wav.ndim == 2:
+        wav = wav.mean(axis=1)
+
+    start = offset or 0
+    end = None if num_frames is None else start + num_frames
+    wav = wav[start:end]
+
+    wav = torch.from_numpy(wav).unsqueeze(0)
+    return wav, sr
+
 """
 Gradio demo for HF-format T5GemmaVoice checkpoints.
 
@@ -185,8 +220,15 @@ def run_inference(
         target_generation_length = float(target_duration)
 
     if not no_reference_audio:
-        info = torchaudio.info(reference_speech)
-        prompt_end_frame = int(cut_off_sec * info.sample_rate)
+        if _torch_ge_29():
+            import soundfile as sf
+            info = sf.info(reference_speech)
+            sr = info.samplerate
+        else:
+            import torchaudio
+            info = torchaudio.info(reference_speech)
+            sr = info.sample_rate
+        prompt_end_frame = int(cut_off_sec * sr)
     else:
         prompt_end_frame = 0
 

--- a/inference_tts_utils.py
+++ b/inference_tts_utils.py
@@ -1,3 +1,38 @@
+
+
+# ==== audio backend helper (auto-added) ====
+def _torch_ge_29():
+    try:
+        import torch
+        v = torch.__version__.split("+")[0]
+        major, minor = map(int, v.split(".")[:2])
+        return (major, minor) >= (2, 9)
+    except Exception:
+        return False
+
+def load_audio_segment(audio_path, offset=0, num_frames=None):
+    if not _torch_ge_29():
+        import torchaudio
+        return torchaudio.load(
+            audio_path,
+            frame_offset=offset,
+            num_frames=num_frames
+        )
+
+    import soundfile as sf
+    import torch
+
+    wav, sr = sf.read(audio_path)
+    if wav.ndim == 2:
+        wav = wav.mean(axis=1)
+
+    start = offset or 0
+    end = None if num_frames is None else start + num_frames
+    wav = wav[start:end]
+
+    wav = torch.from_numpy(wav).unsqueeze(0)
+    return wav, sr
+
 import argparse
 import logging
 import os

--- a/main.py
+++ b/main.py
@@ -1,3 +1,38 @@
+
+
+# ==== audio backend helper (auto-added) ====
+def _torch_ge_29():
+    try:
+        import torch
+        v = torch.__version__.split("+")[0]
+        major, minor = map(int, v.split(".")[:2])
+        return (major, minor) >= (2, 9)
+    except Exception:
+        return False
+
+def load_audio_segment(audio_path, offset=0, num_frames=None):
+    if not _torch_ge_29():
+        import torchaudio
+        return torchaudio.load(
+            audio_path,
+            frame_offset=offset,
+            num_frames=num_frames
+        )
+
+    import soundfile as sf
+    import torch
+
+    wav, sr = sf.read(audio_path)
+    if wav.ndim == 2:
+        wav = wav.mean(axis=1)
+
+    start = offset or 0
+    end = None if num_frames is None else start + num_frames
+    wav = wav[start:end]
+
+    wav = torch.from_numpy(wav).unsqueeze(0)
+    return wav, sr
+
 from pathlib import Path
 import torch, os
 

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,3 +1,38 @@
+
+
+# ==== audio backend helper (auto-added) ====
+def _torch_ge_29():
+    try:
+        import torch
+        v = torch.__version__.split("+")[0]
+        major, minor = map(int, v.split(".")[:2])
+        return (major, minor) >= (2, 9)
+    except Exception:
+        return False
+
+def load_audio_segment(audio_path, offset=0, num_frames=None):
+    if not _torch_ge_29():
+        import torchaudio
+        return torchaudio.load(
+            audio_path,
+            frame_offset=offset,
+            num_frames=num_frames
+        )
+
+    import soundfile as sf
+    import torch
+
+    wav, sr = sf.read(audio_path)
+    if wav.ndim == 2:
+        wav = wav.mean(axis=1)
+
+    start = offset or 0
+    end = None if num_frames is None else start + num_frames
+    wav = wav[start:end]
+
+    wav = torch.from_numpy(wav).unsqueeze(0)
+    return wav, sr
+
 from .t5gemma import T5GemmaVoiceModel
 
 __all__ = ["T5GemmaVoiceModel"]

--- a/models/t5gemma.py
+++ b/models/t5gemma.py
@@ -1,3 +1,38 @@
+
+
+# ==== audio backend helper (auto-added) ====
+def _torch_ge_29():
+    try:
+        import torch
+        v = torch.__version__.split("+")[0]
+        major, minor = map(int, v.split(".")[:2])
+        return (major, minor) >= (2, 9)
+    except Exception:
+        return False
+
+def load_audio_segment(audio_path, offset=0, num_frames=None):
+    if not _torch_ge_29():
+        import torchaudio
+        return torchaudio.load(
+            audio_path,
+            frame_offset=offset,
+            num_frames=num_frames
+        )
+
+    import soundfile as sf
+    import torch
+
+    wav, sr = sf.read(audio_path)
+    if wav.ndim == 2:
+        wav = wav.mean(axis=1)
+
+    start = offset or 0
+    end = None if num_frames is None else start + num_frames
+    wav = wav[start:end]
+
+    wav = torch.from_numpy(wav).unsqueeze(0)
+    return wav, sr
+
 import logging
 from typing import Callable, Dict, List, Optional, Tuple, Union
 

--- a/models/utils.py
+++ b/models/utils.py
@@ -1,3 +1,38 @@
+
+
+# ==== audio backend helper (auto-added) ====
+def _torch_ge_29():
+    try:
+        import torch
+        v = torch.__version__.split("+")[0]
+        major, minor = map(int, v.split(".")[:2])
+        return (major, minor) >= (2, 9)
+    except Exception:
+        return False
+
+def load_audio_segment(audio_path, offset=0, num_frames=None):
+    if not _torch_ge_29():
+        import torchaudio
+        return torchaudio.load(
+            audio_path,
+            frame_offset=offset,
+            num_frames=num_frames
+        )
+
+    import soundfile as sf
+    import torch
+
+    wav, sr = sf.read(audio_path)
+    if wav.ndim == 2:
+        wav = wav.mean(axis=1)
+
+    start = offset or 0
+    end = None if num_frames is None else start + num_frames
+    wav = wav[start:end]
+
+    wav = torch.from_numpy(wav).unsqueeze(0)
+    return wav, sr
+
 import torch
 import torch.nn.functional as F
 

--- a/scripts/export_t5gemma_voice_hf.py
+++ b/scripts/export_t5gemma_voice_hf.py
@@ -1,3 +1,38 @@
+
+
+# ==== audio backend helper (auto-added) ====
+def _torch_ge_29():
+    try:
+        import torch
+        v = torch.__version__.split("+")[0]
+        major, minor = map(int, v.split(".")[:2])
+        return (major, minor) >= (2, 9)
+    except Exception:
+        return False
+
+def load_audio_segment(audio_path, offset=0, num_frames=None):
+    if not _torch_ge_29():
+        import torchaudio
+        return torchaudio.load(
+            audio_path,
+            frame_offset=offset,
+            num_frames=num_frames
+        )
+
+    import soundfile as sf
+    import torch
+
+    wav, sr = sf.read(audio_path)
+    if wav.ndim == 2:
+        wav = wav.mean(axis=1)
+
+    start = offset or 0
+    end = None if num_frames is None else start + num_frames
+    wav = wav[start:end]
+
+    wav = torch.from_numpy(wav).unsqueeze(0)
+    return wav, sr
+
 """Convert a T5Gemma-TTS checkpoint (.pth) to HF safetensors with trust_remote_code.
 
 Usage:

--- a/scripts/export_t5gemma_voice_hf_lora.py
+++ b/scripts/export_t5gemma_voice_hf_lora.py
@@ -1,3 +1,38 @@
+
+
+# ==== audio backend helper (auto-added) ====
+def _torch_ge_29():
+    try:
+        import torch
+        v = torch.__version__.split("+")[0]
+        major, minor = map(int, v.split(".")[:2])
+        return (major, minor) >= (2, 9)
+    except Exception:
+        return False
+
+def load_audio_segment(audio_path, offset=0, num_frames=None):
+    if not _torch_ge_29():
+        import torchaudio
+        return torchaudio.load(
+            audio_path,
+            frame_offset=offset,
+            num_frames=num_frames
+        )
+
+    import soundfile as sf
+    import torch
+
+    wav, sr = sf.read(audio_path)
+    if wav.ndim == 2:
+        wav = wav.mean(axis=1)
+
+    start = offset or 0
+    end = None if num_frames is None else start + num_frames
+    wav = wav[start:end]
+
+    wav = torch.from_numpy(wav).unsqueeze(0)
+    return wav, sr
+
 """
 Export a LoRA-finetuned T5Gemma-TTS checkpoint to a Hugging Face format.
 

--- a/steps/__init__.py
+++ b/steps/__init__.py
@@ -1,0 +1,35 @@
+
+
+# ==== audio backend helper (auto-added) ====
+def _torch_ge_29():
+    try:
+        import torch
+        v = torch.__version__.split("+")[0]
+        major, minor = map(int, v.split(".")[:2])
+        return (major, minor) >= (2, 9)
+    except Exception:
+        return False
+
+def load_audio_segment(audio_path, offset=0, num_frames=None):
+    if not _torch_ge_29():
+        import torchaudio
+        return torchaudio.load(
+            audio_path,
+            frame_offset=offset,
+            num_frames=num_frames
+        )
+
+    import soundfile as sf
+    import torch
+
+    wav, sr = sf.read(audio_path)
+    if wav.ndim == 2:
+        wav = wav.mean(axis=1)
+
+    start = offset or 0
+    end = None if num_frames is None else start + num_frames
+    wav = wav[start:end]
+
+    wav = torch.from_numpy(wav).unsqueeze(0)
+    return wav, sr
+

--- a/steps/optim.py
+++ b/steps/optim.py
@@ -1,3 +1,38 @@
+
+
+# ==== audio backend helper (auto-added) ====
+def _torch_ge_29():
+    try:
+        import torch
+        v = torch.__version__.split("+")[0]
+        major, minor = map(int, v.split(".")[:2])
+        return (major, minor) >= (2, 9)
+    except Exception:
+        return False
+
+def load_audio_segment(audio_path, offset=0, num_frames=None):
+    if not _torch_ge_29():
+        import torchaudio
+        return torchaudio.load(
+            audio_path,
+            frame_offset=offset,
+            num_frames=num_frames
+        )
+
+    import soundfile as sf
+    import torch
+
+    wav, sr = sf.read(audio_path)
+    if wav.ndim == 2:
+        wav = wav.mean(axis=1)
+
+    start = offset or 0
+    end = None if num_frames is None else start + num_frames
+    wav = wav[start:end]
+
+    wav = torch.from_numpy(wav).unsqueeze(0)
+    return wav, sr
+
 # Copyright      2022  Xiaomi Corp.        (authors: Daniel Povey)
 #
 # See ../LICENSE for clarification regarding multiple authors

--- a/steps/trainer.py
+++ b/steps/trainer.py
@@ -1,3 +1,38 @@
+
+
+# ==== audio backend helper (auto-added) ====
+def _torch_ge_29():
+    try:
+        import torch
+        v = torch.__version__.split("+")[0]
+        major, minor = map(int, v.split(".")[:2])
+        return (major, minor) >= (2, 9)
+    except Exception:
+        return False
+
+def load_audio_segment(audio_path, offset=0, num_frames=None):
+    if not _torch_ge_29():
+        import torchaudio
+        return torchaudio.load(
+            audio_path,
+            frame_offset=offset,
+            num_frames=num_frames
+        )
+
+    import soundfile as sf
+    import torch
+
+    wav, sr = sf.read(audio_path)
+    if wav.ndim == 2:
+        wav = wav.mean(axis=1)
+
+    start = offset or 0
+    end = None if num_frames is None else start + num_frames
+    wav = wav[start:end]
+
+    wav = torch.from_numpy(wav).unsqueeze(0)
+    return wav, sr
+
 import copy
 import json
 import logging

--- a/steps/trainer_utils.py
+++ b/steps/trainer_utils.py
@@ -1,4 +1,39 @@
 
+
+# ==== audio backend helper (auto-added) ====
+def _torch_ge_29():
+    try:
+        import torch
+        v = torch.__version__.split("+")[0]
+        major, minor = map(int, v.split(".")[:2])
+        return (major, minor) >= (2, 9)
+    except Exception:
+        return False
+
+def load_audio_segment(audio_path, offset=0, num_frames=None):
+    if not _torch_ge_29():
+        import torchaudio
+        return torchaudio.load(
+            audio_path,
+            frame_offset=offset,
+            num_frames=num_frames
+        )
+
+    import soundfile as sf
+    import torch
+
+    wav, sr = sf.read(audio_path)
+    if wav.ndim == 2:
+        wav = wav.mean(axis=1)
+
+    start = offset or 0
+    end = None if num_frames is None else start + num_frames
+    wav = wav[start:end]
+
+    wav = torch.from_numpy(wav).unsqueeze(0)
+    return wav, sr
+
+
 import torch
 import math
 import torch.distributed as dist


### PR DESCRIPTION
Starting with PyTorch 2.9, torchaudio internally depends on TorchCodec for audio loading and saving operations.
In environments where TorchCodec is unavailable or incompatible, this results in runtime errors.

In addition, PyTorch 2.9 can trigger a data type mismatch error (Float vs Double) when using torchaudio.transforms.Resample.

Since DGX Spark only supports PyTorch 2.9 and later, this patch updates the codebase to ensure compatibility with those environments.